### PR TITLE
Fix custom-domain site URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![pages-build-deployment](https://github.com/JasonYanxx/JasonYanxx.github.io/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/JasonYanxx/JasonYanxx.github.io/actions/workflows/pages/pages-build-deployment)
 
-This repository powers <https://jasonyanxx.github.io/>. It is based on the Academic Pages Jekyll template and is deployed with GitHub Pages.
+This repository powers <https://pgyan.com/>. It is based on the Academic Pages Jekyll template and is deployed with GitHub Pages.
 
 ## Common Content Files
 

--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ title                    : "Penggao Yan"
 title_separator          : "-"
 name                     : &name "Penggao Yan"
 description              : &description "Postdoctoral researcher at The Hong Kong Polytechnic University working on GNSS integrity, robust localization, and uncertainty quantification."
-url                      : https://jasonyanxx.github.io # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
+url                      : https://pgyan.com # the public custom domain
 baseurl                  : "" # the subpath of your site, e.g. "/blog"
 repository               : "jasonyanxx.github.io"
 masthead_title           : "Penggao Yan"
@@ -35,7 +35,7 @@ author:
   bio              : "Postdoctoral researcher at PolyU working on trusted autonomy, navigation integrity, and uncertainty quantification."
   location         : "Hong Kong SAR"
   employer         : "The Hong Kong Polytechnic University (PolyU)"
-  uri              : "https://jasonyanxx.github.io"
+  uri              : "https://pgyan.com"
   email            : "penggao.yan@polyu.edu.hk" 
 
   # Academic websites
@@ -149,7 +149,7 @@ social:
   type                   : "Person"
   name                   : "Penggao Yan"
   links:
-    - "https://jasonyanxx.github.io"
+    - "https://pgyan.com"
     - "https://scholar.google.com/citations?hl=en&user=GKmpir8AAAAJ"
     - "https://orcid.org/0000-0003-0994-9258"
     - "https://www.researchgate.net/profile/Penggao-Yan"


### PR DESCRIPTION
## Summary

- set Jekyll's public base URL to https://pgyan.com
- update the author profile and Person schema home-page references
- align the repository README with the custom domain

## Why

GitHub Pages, DNS, the CNAME file, and HTTPS already serve pgyan.com, but generated canonical tags, social metadata, navigation, and static assets still used jasonyanxx.github.io. That split could make the custom-domain page request assets through the old hostname.

## Validation

- bundle exec jekyll build
- bundle exec jekyll build --safe
- generated home page emits pgyan.com for canonical, Open Graph, CSS, JavaScript, image, feed, navigation, and Person schema URLs

## Intentionally unchanged

DNS records, GitHub Pages settings, repository identity, and website content are unchanged.